### PR TITLE
Added refresh to list of var-injected commands

### DIFF
--- a/infra/infra.go
+++ b/infra/infra.go
@@ -78,7 +78,7 @@ func (p *Proxy) shouldInjectVars(args []string) bool {
 		return false
 	}
 
-	return args[0] == "plan" || args[0] == "apply" || args[0] == "destroy"
+	return args[0] == "plan" || args[0] == "apply" || args[0] == "destroy" || args[0] == "refresh"
 }
 
 // Output fetches output variable `name` from terraform.


### PR DESCRIPTION
- When creating terraform resources that use dynamic names based on variables (i.e. environment name), Apex does not allow you to reconcile the existing AWS infrastructure with apex infra refresh - since the variable names translate to nulls. This change adds refresh to the list of included (plan, apply, destroy, _refresh) actions.